### PR TITLE
Fix abricate_2_table

### DIFF
--- a/scripts/abricate_2_table
+++ b/scripts/abricate_2_table
@@ -120,7 +120,7 @@ for my $file (sort @files){
 			if ($perc_id > $pre_id){
 		
 				# remove file extension
-				$sample =~ s/\.fsa$||\.fasta$||\.fa$||\.gff$||\.gbk$//g;
+				$sample =~ s/\.fsa$||\.fasta$||\.fa$||\.gff$||\.gbk$||\.fas$//g;
 				$sample =~ s/#//g;
 				$sample = basename($sample);
 		


### PR DESCRIPTION
Allows script to interpret fasta filenames with the extension .fas. The .fsa equivalent could be a typo of this option.